### PR TITLE
💲 these dollar signs are not math syntax delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ I moved to [Studio](https://www.bricklink.com/v3/studio/download.page).
 Studio imported the [LDR model](business_card_holder.ldr) just fine.
 
 I've been wanting to swap out the 3895 Technic 1x12 brick because the color
-showed on the sides and there's little reason to waste a $.60 part on this
-when 3 cheaper parts will do.  Right now the blue 3010 is $.08 and the dark
-bluish gray is also $.08, so you're saving $.34.
+showed on the sides and there's little reason to waste a <span>$</span>.60 part
+on this when 3 cheaper parts will do.  Right now the blue 3010 is
+<span>$</span>.08 and the dark bluish gray is also <span>$</span>.08, so you're
+saving <span>$</span>.34.
 
 I then took the [Lime and Yellow version in Studio](business_card_holder2.io)
 and made a [Blue and White version](business_card_holder2_blue.io).


### PR DESCRIPTION
## context

<!--
    What is the problem you are trying to solve?
    Is there a github issue that is related?
    Are there any URLs that would make this easier to figure out?
-->

The formatting looks weird because github is taking the dollar signs (`$`) to mean math expressions instead of a literal dollar sign.

![Screenshot 2025-07-03 at 6 30 12 AM](https://github.com/user-attachments/assets/f091da3b-4822-436d-9b12-38a718f2db22)


## action

<!--
    What did you do?
    What else did you do?
    Did you do anything the reviewer should focus on making sure it is right?
-->

Followed [github docs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions#writing-dollar-signs-in-line-with-and-within-mathematical-expressions) to fix this.

## verify

<!--
    How did you verify that your action worked?
    Did you include positive and negative example test cases or links to something like that?
    Are there any brief samples of what you are seeing in the termainal?

    Please use code blocks for text of error messages or terminal output.
    An image may convey the same information, but it is much more difficult to work with.
    Take the time and do the copy and paste inside of a code block.
-->

The preview in this PR looks better:

![Screenshot 2025-07-03 at 6 33 13 AM](https://github.com/user-attachments/assets/b875fea7-cb54-44cc-a9a3-8336f0b4232f)


so https://github.com/chicks-net/lego-business-card-holder should look ok.
